### PR TITLE
fix typo in en.yml, 'Japanese overtime [a]llowed'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
     attributes:
       ruleset:
         overtime_required:      "Overtime required"
-        j_ot_allowed:           "Japanese overtime llowed"
+        j_ot_allowed:           "Japanese overtime allowed"
         c_ot_allowed:           "Canadian overtime allowed"
         main_time_min:          "Minimum time"
         main_time_max:          "Maximum time"


### PR DESCRIPTION
Typo fix
